### PR TITLE
Parametrize notebook tests and skip heavy notebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,18 @@ pytest --nbmake notebooks/01_BigData_Intro.ipynb
 pytest --nbmake notebooks/02_Graphs_Fundamentals.ipynb
 ```
 
+### Pruebas de notebooks
+
+El conjunto de tests incluye la ejecución automática de los notebooks del
+proyecto.  Las notebooks consideradas pesadas se omiten por defecto para
+agilizar la suite.  Para ejecutarlas todas puede utilizarse la variable de
+entorno `RUN_ALL_NOTEBOOKS`:
+
+```bash
+pytest tests/test_notebooks.py          # solo notebooks livianas
+RUN_ALL_NOTEBOOKS=1 pytest tests/test_notebooks.py  # incluye las pesadas
+```
+
 ## 📓 Notebooks (abrir en Colab)
 - 01 Big Data Intro – [Open in Colab](https://colab.research.google.com/github/sgevatschnaider/BigData-Graphs-Evo-CA-Classroom/blob/main/notebooks/01_BigData_Intro.ipynb)
 - 02 Graphs Fundamentals – [Open in Colab](https://colab.research.google.com/github/sgevatschnaider/BigData-Graphs-Evo-CA-Classroom/blob/main/notebooks/02_Graphs_Fundamentals.ipynb)

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -1,12 +1,42 @@
-import nbformat
-from nbconvert.preprocessors import ExecutePreprocessor
+"""Execution tests for project notebooks.
+
+Each notebook is executed in isolation using ``pytest.mark.parametrize``
+so that failures are reported per file.  Heavy notebooks are skipped unless
+the environment variable ``RUN_ALL_NOTEBOOKS=1`` is provided.
+"""
+
+from __future__ import annotations
+
+import os
 from pathlib import Path
 
+import nbformat
+import pytest
+from nbconvert.preprocessors import ExecutePreprocessor
 
-def test_execute_notebooks():
-    notebooks = Path('notebooks').glob('*.ipynb')
-    for nb_file in notebooks:
-        with open(nb_file, 'r', encoding='utf-8') as f:
-            nb = nbformat.read(f, as_version=4)
-        ep = ExecutePreprocessor(timeout=300, kernel_name='python3')
-        ep.preprocess(nb, {'metadata': {'path': '.'}})
+# Path to all notebooks in the repository
+NOTEBOOK_DIR = Path("notebooks")
+
+# Notebooks that require considerable resources/time
+HEAVY_NOTEBOOKS = {
+    "03_Evolutionary_Algorithms.ipynb",
+    "04_Cellular_Automata.ipynb",
+}
+
+ALL_NOTEBOOKS = list(NOTEBOOK_DIR.glob("*.ipynb"))
+
+
+@pytest.mark.parametrize("nb_file", ALL_NOTEBOOKS, ids=lambda p: p.stem)
+def test_execute_notebook(nb_file: Path) -> None:
+    """Execute a single notebook and ensure it runs without errors."""
+
+    run_all = os.environ.get("RUN_ALL_NOTEBOOKS") == "1"
+    if not run_all and nb_file.name in HEAVY_NOTEBOOKS:
+        pytest.skip("Skipping heavy notebook. Set RUN_ALL_NOTEBOOKS=1 to run.")
+
+    with open(nb_file, "r", encoding="utf-8") as f:
+        nb = nbformat.read(f, as_version=4)
+
+    ep = ExecutePreprocessor(timeout=300, kernel_name="python3")
+    ep.preprocess(nb, {"metadata": {"path": "."}})
+


### PR DESCRIPTION
## Summary
- Run each notebook as a separate parametrized test
- Skip heavy notebooks unless `RUN_ALL_NOTEBOOKS=1`
- Document how to run the full vs partial notebook tests

## Testing
- `pytest tests/test_notebooks.py -q` *(fails: ModuleNotFoundError: No module named 'nbconvert')*


------
https://chatgpt.com/codex/tasks/task_e_68a140fb2164832c81d8337d7360aa22