### PR TITLE
Annotate Spark session creation

### DIFF
--- a/src/classroom/bigdata/spark_utils.py
+++ b/src/classroom/bigdata/spark_utils.py
@@ -1,13 +1,22 @@
 """Funciones de utilidad para trabajar con PySpark (opcional)."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 try:
     from pyspark.sql import SparkSession  # type: ignore
 except ImportError:  # pragma: no cover
-    SparkSession = None
+    SparkSession = None  # type: ignore[assignment]
+
+if TYPE_CHECKING:  # pragma: no cover
+    from pyspark.sql import SparkSession
 
 
-def create_session(app_name: str = "classroom"):
+def create_session(app_name: str = "classroom") -> SparkSession:
     """Crea una SparkSession. Requiere pyspark instalado."""
     if SparkSession is None:
-        raise ImportError("pyspark no está instalado. Instala el extra [spark] para usar esta función.")
+        raise ImportError(
+            "pyspark no está instalado. Instala el extra [spark] para usar esta función."
+        )
     return SparkSession.builder.appName(app_name).getOrCreate()


### PR DESCRIPTION
## Summary
- add return type annotation for Spark session creation helper
- guard SparkSession typing when PySpark is absent

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'classroom', ModuleNotFoundError: No module named 'nbconvert')*

------
https://chatgpt.com/codex/tasks/task_e_68a140f925ec832c9776532bcd4e95c4