### PR TITLE
Fix asset check in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
           pip install -r requirements.txt
       - name: Sanity check: asset exists
         run: |
-          test -f docs/assets/modelo-erdos-renyi.html|| { echo "Falta docs/assets/modelo-erdos-renyi.htm"; exit 1; }
+          test -f docs/assets/modelo-erdos-renyi.html || { echo "Falta docs/assets/modelo-erdos-renyi.html"; exit 1; }
       - name: Build MkDocs
         run: mkdocs build --strict --site-dir site
       - name: Configure Pages


### PR DESCRIPTION
## Summary
- fix typo in GitHub Pages workflow sanity check for modelo-erdos-renyi asset

## Testing
- `pre-commit run --files .github/workflows/deploy.yml` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'classroom')*


------
https://chatgpt.com/codex/tasks/task_e_68a4cff1287c832cb4703f7131081f41