### PR TITLE
Add BOIDS multigroup Colab laboratory

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Este repositorio se complementa con [GraphAI-Data-Science-ML](https://github.com
 * [🎯 Público Objetivo y Requisitos](#-público-objetivo-y-requisitos)
 * [🛠️ Uso y Ejecución](#️-uso-y-ejecución)
 * [📚 Módulos y Notebooks](#-módulos-y-notebooks)
+* [🐦 Laboratorio destacado: BOIDS multigrupo](#-laboratorio-destacado-boids-multigrupo)
 * [🗺️ Roadmap del Proyecto](#️-roadmap-del-proyecto)
 * [📂 Estructura del Repositorio](#-estructura-del-repositorio)
 * [🤝 Cómo Contribuir](#-cómo-contribuir)
@@ -135,6 +136,48 @@ BigData-Graphs-Evo-CA-Classroom/
 </details>
 
 ---
+
+## 🐦 Laboratorio destacado: BOIDS multigrupo
+
+<div align="center">
+  <h3>BOIDS multigrupo: reglas locales, segregación y diagramas de fases</h3>
+  <p><strong>Align to alike, avoid aliens.</strong></p>
+  <p><em>Reglas locales. Dinámicas complejas. Fronteras persistentes.</em></p>
+  <p>
+    Laboratorio reproducible en Python para explorar cómo la separación, el alineamiento,
+    la cohesión y la evitación intergrupal producen comportamiento colectivo emergente.
+  </p>
+  <p>
+    <a href="https://colab.research.google.com/drive/1QyioTMdCgWpoQrnnEi7vpHqTJ_7eB2Td?usp=sharing">
+      <img alt="Abrir laboratorio en Google Colab" src="https://img.shields.io/badge/Abrir%20laboratorio-Google%20Colab-F9AB00?style=for-the-badge&logo=googlecolab&logoColor=white" />
+    </a>
+    &nbsp;
+    <a href="./src/classroom/graphs/notebooks/boids-multigrupo-diagrama-fases.ipynb">
+      <img alt="Ver notebook en GitHub" src="https://img.shields.io/badge/Ver%20notebook-GitHub-181717?style=for-the-badge&logo=github" />
+    </a>
+  </p>
+</div>
+
+| 🔍 Explora | 📊 Mide | 🧪 Experimenta |
+|:---:|:---:|:---:|
+| Tres grupos de agentes y reglas locales | Orden, segregación y exposición a fronteras | Escenarios, semillas e intervenciones |
+| Bandadas, cardúmenes, drones o agentes de IA | Series temporales y diagramas de fases | Persistencia e histéresis espacial |
+
+<details>
+<summary><strong>¿Qué encontrarás en el laboratorio?</strong></summary>
+
+- Desarrollo teórico del modelo BOIDS y su extensión multigrupo.
+- Simulación vectorizada con NumPy y visualizaciones con Matplotlib.
+- Animación y controles interactivos para Google Colab.
+- Comparación de regímenes colectivos y barrido de parámetros.
+- Análisis de sensibilidad, reproducibilidad y límites de las analogías sociales.
+
+</details>
+
+> Material elaborado por el profesor **Sergio Gevatschnaider** para el estudio de grafos, simulación basada en agentes y sistemas complejos.
+
+---
+
 # Notebooks Interactivos  
 Puedes abrir y ejecutar los notebooks en Google Colab directamente desde aquí:  
 

--- a/src/classroom/graphs/README.md
+++ b/src/classroom/graphs/README.md
@@ -79,6 +79,11 @@
 - Notebook/script: `notebooks/06_hyperbolic_embeddings_poincare.(ipynb|py)`
 - Referencias: `references/README.md`
 
+### H) Sistemas complejos y comportamiento emergente
+- BOIDS multigrupo: separación, alineamiento, cohesión y evitación intergrupal.
+- Orden colectivo, segregación espacial, fronteras persistentes y diagramas de fases.
+- Notebook Colab reproducible con animación, controles, métricas y análisis de sensibilidad.
+
 ---
 
 ## Estructura local
@@ -134,6 +139,7 @@ Abre los cuadernos en `notebooks/` para la ruta guiada.
 
 ## Tabla de contenidos
 
+* [🐦 Laboratorio BOIDS multigrupo](#-laboratorio-boids-multigrupo)
 * [1) Fundamentos teóricos](#1-fundamentos-teóricos)
 * [2) Algoritmos esenciales (y complejidad)](#2-algoritmos-esenciales-y-complejidad)
 * [3) Métricas y análisis de redes](#3-métricas-y-análisis-de-redes)
@@ -151,6 +157,52 @@ Abre los cuadernos en `notebooks/` para la ruta guiada.
 * [Apéndice B — Plantilla mínima de notebook](#apéndice-b--plantilla-mínima-de-notebook)
 
 
+
+## 🐦 Laboratorio BOIDS multigrupo
+
+<div align="center">
+  <h3>Reglas locales, segregación y diagramas de fases</h3>
+  <p><strong>Align to alike, avoid aliens.</strong></p>
+  <p>
+    Un laboratorio de sistemas complejos donde tres poblaciones de agentes responden únicamente
+    a sus vecinos y, sin líder central, producen orden colectivo, agrupamiento y fronteras emergentes.
+  </p>
+  <p>
+    <a href="https://colab.research.google.com/drive/1QyioTMdCgWpoQrnnEi7vpHqTJ_7eB2Td?usp=sharing">
+      <img alt="Abrir laboratorio en Google Colab" src="https://img.shields.io/badge/Abrir%20laboratorio-Google%20Colab-F9AB00?style=for-the-badge&logo=googlecolab&logoColor=white" />
+    </a>
+    &nbsp;
+    <a href="./notebooks/boids-multigrupo-diagrama-fases.ipynb">
+      <img alt="Ver notebook en GitHub" src="https://img.shields.io/badge/Ver%20notebook-GitHub-181717?style=for-the-badge&logo=github" />
+    </a>
+  </p>
+</div>
+
+### Pregunta central
+
+> ¿Cómo pueden reglas microscópicas sencillas generar estructuras macroscópicas complejas y persistentes?
+
+El notebook parte del modelo BOIDS clásico —**separación, alineamiento y cohesión**— y añade interacción multigrupo. La simulación permite estudiar por separado tres propiedades que suelen confundirse:
+
+| Propiedad | Pregunta | Métrica |
+|---|---|---:|
+| **Orden direccional** | ¿Los agentes se desplazan en una dirección común? | Polarización `P` |
+| **Segregación espacial** | ¿Los vecinos pertenecen predominantemente al mismo grupo? | Índice `S` |
+| **Frontera intergrupal** | ¿Cuántos agentes permanecen expuestos a otros grupos? | Exposición `B` |
+
+### Recorrido del laboratorio
+
+1. Formulación matemática y condiciones periódicas sobre un toro.
+2. Implementación vectorizada y pruebas básicas del simulador.
+3. Animación de tres grupos y panel de parámetros interactivos.
+4. Comparación controlada de cuatro regímenes colectivos.
+5. Construcción de un diagrama de fases mediante múltiples simulaciones.
+6. Intervención para medir persistencia de fronteras y memoria estructural.
+7. Sensibilidad a semillas y discusión sobre aves, peces, drones, redes y agentes de IA.
+
+> **Nota metodológica:** es un modelo generativo mínimo. Mostrar que una regla puede producir segregación no demuestra que esa regla explique por sí sola un fenómeno social real.
+
+---
 
 ## 📝 Fundamentos de la Teoría de Grafos
 

--- a/src/classroom/graphs/notebooks/boids-multigrupo-diagrama-fases.ipynb
+++ b/src/classroom/graphs/notebooks/boids-multigrupo-diagrama-fases.ipynb
@@ -1,0 +1,216 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "<div style=\"padding:24px;border-radius:18px;background:linear-gradient(135deg,#081c33,#173b5e);color:#f7fbff\">\n  <div style=\"font-size:13px;letter-spacing:.12em;text-transform:uppercase;opacity:.8\">Laboratorio de sistemas complejos · Python + Google Colab</div>\n  <h1 style=\"margin:.35em 0 .2em\">Align to alike, avoid aliens</h1>\n  <h2 style=\"margin:.1em 0;font-weight:400\">BOIDS multigrupo: reglas locales, segregación y fronteras emergentes</h2>\n  <p style=\"max-width:850px;margin-top:16px\">Tres bandadas, cardúmenes, enjambres o poblaciones de agentes. Nadie dirige al conjunto: cada agente solo observa una vecindad local. Aun así aparecen orden colectivo, agrupamiento, separación y memoria espacial.</p>\n  <p style=\"margin-bottom:0;opacity:.8\">Material elaborado por el profesor Sergio Gevatschnaider</p>\n</div>\n\n> **Idea central.** Este notebook no busca que “mires puntos moverse”, sino que puedas formular hipótesis, medir resultados y construir un diagrama de fases reproducible."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Objetivos de aprendizaje\n\nAl finalizar podrás:\n\n1. Explicar cómo **separación**, **alineamiento** y **cohesión** producen flocking sin líder.\n2. Extender BOIDS a tres grupos mediante **homofilia local** y **evitación intergrupal**.\n3. Distinguir orden dinámico, segregación espacial y exposición a fronteras.\n4. Construir un **diagrama de fases** mediante barridos de parámetros y réplicas aleatorias.\n5. Analizar sensibilidad a condiciones iniciales, transitorios, persistencia e histéresis.\n6. Discutir qué se puede —y qué no se puede— inferir sobre aves, peces, drones, redes sociales, naciones o agentes de IA.\n\n### Recorrido\n\n| Bloque | Pregunta | Producto |\n|---|---|---|\n| 1. Modelo | ¿Qué información local usa cada agente? | Ecuaciones y algoritmo |\n| 2. Simulación | ¿Qué patrones aparecen con tres grupos? | Trayectorias y animación |\n| 3. Medición | ¿Orden y segregación son lo mismo? | Series temporales y métricas |\n| 4. Experimentos | ¿Qué regla causa qué patrón? | Comparación controlada |\n| 5. Diagrama de fases | ¿Dónde cambia el régimen colectivo? | Mapas paramétricos |\n| 6. Persistencia | ¿Las fronteras sobreviven al cambio de reglas? | Experimento de intervención |"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 1. De reglas locales a propiedades globales\n\nEl modelo BOIDS clásico de Craig Reynolds representa a cada agente $i$ mediante posición $\\mathbf{x}_i(t)\\in[0,L)^2$ y velocidad $\\mathbf{v}_i(t)$. En cada paso, el agente responde a vecinos dentro de radios de percepción; no conoce el estado global.\n\nPara una vecindad $\\mathcal N_i$:\n\n$$\n\\mathbf a_i=\nw_s\\mathbf S_i +\nw_a\\mathbf A_i +\nw_c\\mathbf C_i +\nw_o\\mathbf O_i +\n\\sigma\\boldsymbol\\eta_i.\n$$\n\n- **Separación $\\mathbf S_i$:** alejarse de cualquier agente demasiado próximo; evita colisiones.\n- **Alineamiento $\\mathbf A_i$:** aproximar la velocidad a la de vecinos del mismo grupo.\n- **Cohesión $\\mathbf C_i$:** dirigirse hacia el centro local de vecinos semejantes.\n- **Evitación intergrupal $\\mathbf O_i$:** alejarse de vecinos de otros grupos.\n- **Ruido $\\boldsymbol\\eta_i$:** perturbaciones, errores de percepción o decisiones no modeladas.\n\nActualizamos con Euler discreto y limitamos la rapidez:\n\n$$\n\\mathbf v_i(t+1)=\\operatorname{clip}_{v_{\\max}}\n\\left[\\mathbf v_i(t)+\\Delta t\\,\\mathbf a_i(t)\\right],\\qquad\n\\mathbf x_i(t+1)=\\big(\\mathbf x_i(t)+\\Delta t\\,\\mathbf v_i(t+1)\\big)\\bmod L.\n$$\n\nEl módulo implementa un **toro**: salir por la derecha equivale a entrar por la izquierda. Así evitamos que una pared artificial sea confundida con una frontera social."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### “Align to alike, avoid aliens”: traducción operacional\n\nEn el código evitaremos usar *aliens* como etiqueta para personas. Formalmente hay solo agentes con una variable categórica $g_i\\in\\{0,1,2\\}$:\n\n$$\n\\mathcal N_i^{\\text{same}}=\\{j:d_{ij}<r_p,\\ g_j=g_i\\},\\qquad\n\\mathcal N_i^{\\text{other}}=\\{j:d_{ij}<r_o,\\ g_j\\neq g_i\\}.\n$$\n\nLa frase se convierte en dos parámetros observables:\n\n- $h$ (**homofilia dinámica**): intensidad de alineamiento/cohesión con el mismo grupo.\n- $q$ (**evitación intergrupal**): intensidad de repulsión frente a otros grupos.\n\nEsto es un **modelo generativo mínimo**, no una teoría de la conducta humana. Que una regla produzca segregación es una demostración de suficiencia computacional, no prueba de que esa regla sea la causa de una segregación real."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# @title 2. Preparación del entorno (ejecutar primero)\nimport math, time, warnings\nfrom dataclasses import dataclass, replace\nfrom typing import Optional\n\nimport numpy as np\nimport pandas as pd\nimport matplotlib.pyplot as plt\nfrom matplotlib import animation\nfrom matplotlib.colors import ListedColormap\nimport seaborn as sns\n\nfrom IPython.display import HTML, display, clear_output\n\nwarnings.filterwarnings(\"ignore\", category=RuntimeWarning)\nsns.set_theme(style=\"whitegrid\", context=\"notebook\")\nplt.rcParams[\"figure.dpi\"] = 115\nplt.rcParams[\"animation.html\"] = \"jshtml\"\n\nPALETTE = np.array([\"#4C78A8\", \"#F58518\", \"#54A24B\"])\nGROUP_NAMES = np.array([\"Grupo A\", \"Grupo B\", \"Grupo C\"])\nSEED = 42\n\nprint(\"Entorno listo · NumPy\", np.__version__, \"· Pandas\", pd.__version__)"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 2. Implementación vectorizada\n\nLa matriz $\\Delta_{ij}=\\mathbf x_j-\\mathbf x_i$ contiene todos los desplazamientos. En un toro usamos la convención de **imagen mínima**:\n\n$$\n\\Delta_{ij}\\leftarrow \\Delta_{ij}-L\\,\\operatorname{round}(\\Delta_{ij}/L).\n$$\n\nAsí, dos agentes situados en $x=0.2$ y $x=19.8$ dentro de una caja $L=20$ están a distancia $0.4$, no $19.6$. La vectorización hace el código claro y rápido para fines docentes; su costo es $O(N^2)$ por paso. Para miles de agentes conviene usar árboles espaciales o *cell lists*."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "@dataclass(frozen=True)\nclass BoidsConfig:\n    n_agents: int = 75\n    n_groups: int = 3\n    box_size: float = 20.0\n    dt: float = 0.12\n    perception_radius: float = 3.0\n    separation_radius: float = 0.75\n    outgroup_radius: float = 2.2\n    separation: float = 1.35\n    alignment: float = 0.85\n    cohesion: float = 0.055\n    outgroup_avoidance: float = 0.55\n    noise: float = 0.035\n    min_speed: float = 0.35\n    max_speed: float = 1.35\n\n\nclass MultiGroupBoids:\n    '''BOIDS bidimensional con tres grupos y condiciones periódicas.'''\n\n    def __init__(self, config=BoidsConfig(), seed=42, init=\"mixed\"):\n        self.cfg = config\n        self.rng = np.random.default_rng(seed)\n        n, L, k = config.n_agents, config.box_size, config.n_groups\n        self.groups = np.arange(n) % k\n        self.rng.shuffle(self.groups)\n\n        if init == \"mixed\":\n            self.pos = self.rng.uniform(0, L, size=(n, 2))\n        elif init == \"segregated\":\n            centers = np.c_[\n                L/2 + 0.28*L*np.cos(2*np.pi*np.arange(k)/k),\n                L/2 + 0.28*L*np.sin(2*np.pi*np.arange(k)/k)\n            ]\n            self.pos = (centers[self.groups] + self.rng.normal(0, 0.9, (n, 2))) % L\n        else:\n            raise ValueError(\"init debe ser 'mixed' o 'segregated'\")\n\n        angles = self.rng.uniform(0, 2*np.pi, n)\n        speeds = self.rng.uniform(config.min_speed, config.max_speed, n)\n        self.vel = np.c_[np.cos(angles), np.sin(angles)] * speeds[:, None]\n        self.t = 0\n\n    def pair_geometry(self):\n        L = self.cfg.box_size\n        delta = self.pos[None, :, :] - self.pos[:, None, :]  # x_j - x_i\n        delta -= L * np.round(delta / L)\n        dist = np.linalg.norm(delta, axis=2)\n        np.fill_diagonal(dist, np.inf)\n        return delta, dist\n\n    @staticmethod\n    def _masked_mean(values, mask):\n        count = mask.sum(axis=1, keepdims=True)\n        total = (values * mask[..., None]).sum(axis=1)\n        return np.divide(total, count, out=np.zeros_like(total), where=count > 0)\n\n    def acceleration(self):\n        c = self.cfg\n        delta, dist = self.pair_geometry()\n        same = self.groups[:, None] == self.groups[None, :]\n        other = ~same\n        np.fill_diagonal(other, False)\n\n        # 1) Separación universal: ponderación inversa al cuadrado.\n        close = dist < c.separation_radius\n        safe_dist = np.maximum(dist, 1e-9)\n        sep = (-delta / safe_dist[..., None]**2 * close[..., None]).sum(axis=1)\n\n        # 2) Alineamiento con semejantes.\n        same_near = same & (dist < c.perception_radius)\n        mean_vel = self._masked_mean(\n            np.broadcast_to(self.vel[None, :, :], delta.shape), same_near\n        )\n        has_same = same_near.any(axis=1)\n        align = np.where(has_same[:, None], mean_vel - self.vel, 0.0)\n\n        # 3) Cohesión: promedio de desplazamientos toroidales hacia semejantes.\n        cohesion = self._masked_mean(delta, same_near)\n\n        # 4) Evitación de otros grupos dentro de un radio específico.\n        out_near = other & (dist < c.outgroup_radius)\n        avoid = (-delta / safe_dist[..., None]**2 * out_near[..., None]).sum(axis=1)\n\n        noise = self.rng.normal(0, 1, self.vel.shape)\n        return (c.separation * sep + c.alignment * align +\n                c.cohesion * cohesion + c.outgroup_avoidance * avoid +\n                c.noise * noise)\n\n    def step(self, steps=1):\n        for _ in range(steps):\n            c = self.cfg\n            self.vel += c.dt * self.acceleration()\n            speed = np.linalg.norm(self.vel, axis=1, keepdims=True)\n            direction = self.vel / np.maximum(speed, 1e-12)\n            target = np.clip(speed, c.min_speed, c.max_speed)\n            self.vel = direction * target\n            self.pos = (self.pos + c.dt * self.vel) % c.box_size\n            self.t += 1\n        return self\n\n    def copy_state(self):\n        return self.pos.copy(), self.vel.copy(), self.groups.copy()\n\n\ndef sanity_checks():\n    cfg = BoidsConfig(n_agents=12)\n    sim = MultiGroupBoids(cfg, seed=1)\n    for _ in range(20):\n        sim.step()\n    speed = np.linalg.norm(sim.vel, axis=1)\n    assert np.isfinite(sim.pos).all() and np.isfinite(sim.vel).all()\n    assert (sim.pos >= 0).all() and (sim.pos < cfg.box_size).all()\n    assert speed.max() <= cfg.max_speed + 1e-9\n    assert speed.min() >= cfg.min_speed - 1e-9\n    return \"Pruebas básicas superadas ✓\"\n\nprint(sanity_checks())"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 3. Cómo medir lo que emerge\n\nUna imagen puede sugerir un patrón, pero no demuestra que exista. Usaremos cuatro métricas:\n\n1. **Orden direccional**\n$$P=\\left\\|\\frac1N\\sum_i \\frac{\\mathbf v_i}{\\|\\mathbf v_i\\|}\\right\\|\\in[0,1].$$\n$P\\approx1$ significa movimiento colectivo alineado; $P\\approx0$ indica direcciones compensadas.\n\n2. **Fracción de vecinos semejantes** $f_s$: entre los pares próximos, proporción que pertenece al mismo grupo.\n\n3. **Segregación corregida por composición**\n$$S=\\frac{f_s-f_0}{1-f_0},\\qquad f_0=\\sum_g p_g^2.$$\n$S\\approx0$ corresponde a mezcla aleatoria; $S\\to1$, a vecindarios homogéneos. Puede ser negativa si hay más contacto intergrupal que el esperado.\n\n4. **Exposición a frontera** $B$: proporción de agentes que tiene al menos un vecino de otro grupo dentro del radio de medición. Una población puede estar muy segregada y conservar una frontera extensa; por eso $S$ y $B$ no son redundantes."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "def metrics(sim, radius=None):\n    radius = radius or sim.cfg.perception_radius\n    _, dist = sim.pair_geometry()\n    near = dist < radius\n    same = sim.groups[:, None] == sim.groups[None, :]\n\n    upper = np.triu(near, 1)\n    total_pairs = upper.sum()\n    same_pairs = (upper & same).sum()\n    same_fraction = same_pairs / total_pairs if total_pairs else np.nan\n\n    proportions = np.bincount(sim.groups, minlength=sim.cfg.n_groups) / len(sim.groups)\n    baseline = np.sum(proportions**2)\n    segregation = ((same_fraction - baseline) / (1 - baseline)\n                   if total_pairs and baseline < 1 else np.nan)\n\n    unit = sim.vel / np.maximum(np.linalg.norm(sim.vel, axis=1, keepdims=True), 1e-12)\n    polarization = np.linalg.norm(unit.mean(axis=0))\n    boundary_exposure = (near & ~same).any(axis=1).mean()\n    mean_neighbors = near.sum(axis=1).mean()\n\n    return dict(\n        t=sim.t,\n        polarization=polarization,\n        segregation=segregation,\n        same_neighbor_fraction=same_fraction,\n        boundary_exposure=boundary_exposure,\n        mean_neighbors=mean_neighbors,\n    )\n\n\ndef run_simulation(config=BoidsConfig(), steps=400, seed=42, init=\"mixed\",\n                   sample_every=5, keep_states=False):\n    sim = MultiGroupBoids(config, seed=seed, init=init)\n    records, states = [], []\n    for t in range(steps + 1):\n        if t % sample_every == 0:\n            records.append(metrics(sim))\n            if keep_states:\n                states.append(sim.copy_state())\n        if t < steps:\n            sim.step()\n    return sim, pd.DataFrame(records), states\n\n\ndef snapshot(sim, ax=None, title=None, arrows=True):\n    if ax is None:\n        _, ax = plt.subplots(figsize=(7, 7))\n    L = sim.cfg.box_size\n    for g in range(sim.cfg.n_groups):\n        m = sim.groups == g\n        ax.scatter(sim.pos[m, 0], sim.pos[m, 1], s=42, color=PALETTE[g],\n                   label=GROUP_NAMES[g], alpha=.88, edgecolor=\"white\", linewidth=.35)\n        if arrows:\n            ax.quiver(sim.pos[m, 0], sim.pos[m, 1], sim.vel[m, 0], sim.vel[m, 1],\n                      color=PALETTE[g], angles=\"xy\", scale_units=\"xy\", scale=2.8,\n                      width=.003, alpha=.65)\n    ax.set(xlim=(0, L), ylim=(0, L), xlabel=\"x\", ylabel=\"y\", aspect=\"equal\")\n    ax.set_title(title or f\"Estado en t={sim.t}\")\n    ax.legend(loc=\"upper right\", frameon=True, ncols=1)\n    return ax"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 4. Primera experiencia: de una mezcla a tres colectivos\n\n**Hipótesis:** con alineamiento y cohesión intragrupal moderados, más evitación intergrupal, aumentará la segregación aun cuando el orden direccional global no necesariamente sea alto. Tres grupos pueden formar tres bandadas que viajan en direcciones distintas: orden local alto, orden global bajo."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# @title Simulación base y diagnóstico visual\nbase_cfg = BoidsConfig(\n    n_agents=75,\n    alignment=0.90,\n    cohesion=0.065,\n    outgroup_avoidance=0.70,\n    noise=0.03,\n)\nbase_sim, base_hist, base_states = run_simulation(\n    base_cfg, steps=500, seed=SEED, sample_every=5, keep_states=True\n)\n\nfig, axes = plt.subplots(1, 2, figsize=(13, 5.6), constrained_layout=True)\n\n# Reconstrucción del estado inicial para compararlo con el final.\ninitial = MultiGroupBoids(base_cfg, seed=SEED, init=\"mixed\")\nsnapshot(initial, axes[0], \"Inicio: mezcla aleatoria\", arrows=False)\nsnapshot(base_sim, axes[1], \"Final: patrón emergente\", arrows=True)\nplt.show()\n\ndisplay(base_hist.tail(1).round(3).rename(index={base_hist.index[-1]: \"valor final\"}))"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# @title Evolución temporal: orden, segregación y frontera\nfig, axes = plt.subplots(1, 3, figsize=(15, 4), sharex=True, constrained_layout=True)\nseries = [\n    (\"polarization\", \"Orden direccional P\", \"#4C78A8\", (0, 1)),\n    (\"segregation\", \"Segregación S\", \"#F58518\", (-.1, 1)),\n    (\"boundary_exposure\", \"Exposición a frontera B\", \"#54A24B\", (0, 1)),\n]\nfor ax, (col, label, color, ylim) in zip(axes, series):\n    ax.plot(base_hist[\"t\"], base_hist[col], lw=2.2, color=color)\n    ax.set(xlabel=\"Paso\", ylabel=label, ylim=ylim)\n    ax.axhline(0, color=\"gray\", lw=.7)\nfig.suptitle(\"Una misma trayectoria, tres propiedades colectivas distintas\", y=1.03)\nplt.show()"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# @title Animación de la trayectoria (puede tardar unos segundos)\ndef animate_states(states, config, interval=55, stride=2):\n    shown = states[::stride]\n    fig, ax = plt.subplots(figsize=(6.4, 6.4))\n    ax.set(xlim=(0, config.box_size), ylim=(0, config.box_size), aspect=\"equal\",\n           xlabel=\"x\", ylabel=\"y\")\n    scatters = []\n    groups = shown[0][2]\n    for g in range(config.n_groups):\n        sc = ax.scatter([], [], s=38, color=PALETTE[g], label=GROUP_NAMES[g],\n                        edgecolor=\"white\", linewidth=.3)\n        scatters.append(sc)\n    ax.legend(loc=\"upper right\")\n    title = ax.set_title(\"\")\n\n    def update(frame):\n        pos, vel, grp = shown[frame]\n        for g, sc in enumerate(scatters):\n            sc.set_offsets(pos[grp == g])\n        title.set_text(f\"BOIDS multigrupo · muestra {frame+1}/{len(shown)}\")\n        return [*scatters, title]\n\n    ani = animation.FuncAnimation(fig, update, frames=len(shown), interval=interval,\n                                  blit=False, repeat=True)\n    plt.close(fig)\n    return ani\n\nani = animate_states(base_states, base_cfg, stride=2)\ndisplay(HTML(ani.to_jshtml()))"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 5. Laboratorio interactivo\n\nMueve los controles y pulsa **Ejecutar experimento**. No cambies todo a la vez si quieres hacer inferencia causal: modifica un parámetro, conserva la semilla y compara.\n\n- **Alineamiento:** sincroniza velocidades del mismo grupo.\n- **Cohesión:** compacta cada grupo.\n- **Evitación intergrupal:** reduce contacto entre grupos.\n- **Ruido:** debilita la coordinación y puede disolver fronteras."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# @title Controles interactivos (ipywidgets)\ntry:\n    import ipywidgets as widgets\n\n    align_w = widgets.FloatSlider(value=.9, min=0, max=1.8, step=.1, description=\"Alineam.\")\n    cohesion_w = widgets.FloatSlider(value=.06, min=0, max=.15, step=.01, description=\"Cohesión\")\n    avoid_w = widgets.FloatSlider(value=.7, min=0, max=1.8, step=.1, description=\"Evitación\")\n    noise_w = widgets.FloatSlider(value=.03, min=0, max=.20, step=.01, description=\"Ruido\")\n    seed_w = widgets.IntSlider(value=42, min=0, max=100, step=1, description=\"Semilla\")\n    run_button = widgets.Button(description=\"Ejecutar experimento\", button_style=\"primary\")\n    out = widgets.Output()\n\n    def run_widget(_):\n        with out:\n            clear_output(wait=True)\n            cfg = replace(base_cfg, alignment=align_w.value, cohesion=cohesion_w.value,\n                          outgroup_avoidance=avoid_w.value, noise=noise_w.value)\n            sim, hist, _ = run_simulation(cfg, steps=350, seed=seed_w.value, sample_every=5)\n            fig, axes = plt.subplots(1, 2, figsize=(12, 5), constrained_layout=True)\n            snapshot(sim, axes[0], \"Estado final\", arrows=False)\n            axes[1].plot(hist.t, hist.polarization, label=\"Orden P\")\n            axes[1].plot(hist.t, hist.segregation, label=\"Segregación S\")\n            axes[1].plot(hist.t, hist.boundary_exposure, label=\"Frontera B\")\n            axes[1].set(xlabel=\"Paso\", ylabel=\"Métrica\", ylim=(-.1, 1.05), title=\"Dinámica\")\n            axes[1].legend()\n            plt.show()\n            display(hist.tail(20).mean(numeric_only=True).to_frame(\"promedio final\").T.round(3))\n\n    run_button.on_click(run_widget)\n    display(widgets.VBox([\n        widgets.HTML(\"<b>Reglas locales</b>\"),\n        widgets.HBox([align_w, cohesion_w]),\n        widgets.HBox([avoid_w, noise_w]),\n        seed_w, run_button, out\n    ]))\n    run_widget(None)\nexcept Exception as exc:\n    print(\"Los widgets no están disponibles. Ejecuta manualmente la simulación base.\", exc)"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 6. Experimentos controlados: cuatro regímenes candidatos\n\nLa etiqueta de un régimen es una interpretación resumida, no una verdad ontológica. Compararemos promedios de la cola temporal para evitar confundir el transitorio inicial con el comportamiento persistente."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# @title Comparación de escenarios con la misma semilla\nscenarios = {\n    \"Desorden ruidoso\": dict(alignment=.15, cohesion=.01, outgroup_avoidance=.05, noise=.16),\n    \"Bandada mixta\": dict(alignment=1.15, cohesion=.045, outgroup_avoidance=0.0, noise=.02),\n    \"Tres bandadas\": dict(alignment=1.05, cohesion=.075, outgroup_avoidance=.85, noise=.025),\n    \"Fragmentación\": dict(alignment=.40, cohesion=.018, outgroup_avoidance=1.55, noise=.08),\n}\n\nscenario_rows, scenario_sims = [], {}\nfor name, pars in scenarios.items():\n    cfg = replace(base_cfg, **pars)\n    sim, hist, _ = run_simulation(cfg, steps=450, seed=23, sample_every=5)\n    tail = hist.tail(20).mean(numeric_only=True)\n    scenario_rows.append({\"escenario\": name, **tail.to_dict()})\n    scenario_sims[name] = sim\n\nscenario_df = pd.DataFrame(scenario_rows).set_index(\"escenario\")\ndisplay(scenario_df[[\"polarization\", \"segregation\", \"boundary_exposure\",\n                     \"mean_neighbors\"]].round(3))\n\nfig, axes = plt.subplots(2, 2, figsize=(11, 10), constrained_layout=True)\nfor ax, (name, sim) in zip(axes.ravel(), scenario_sims.items()):\n    snapshot(sim, ax, name, arrows=False)\n    ax.get_legend().remove()\nhandles, labels = axes[0, 0].get_legend_handles_labels()\nfig.legend(handles, labels, loc=\"outside upper center\", ncols=3)\nplt.show()"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### Lectura esperada\n\n- **Bandada mixta:** puede tener $P$ alto con $S$ cercano a cero. Coordinación no implica segregación.\n- **Tres bandadas:** puede tener $S$ alto y $P$ global intermedio o bajo si cada grupo toma una dirección diferente.\n- **Fragmentación:** una evitación extrema reduce vecinos, de modo que el índice $S$ puede volverse inestable. Siempre hay que leerlo junto con densidad local y exposición.\n- **Desorden ruidoso:** no toda ausencia de orden equivale a mezcla social; puede ser simplemente pérdida de coordinación cinemática."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 7. Diagrama de fases\n\nUn diagrama de fases resume el régimen macroscópico en función de parámetros microscópicos. Barreremos:\n\n- eje horizontal: cohesión intragrupal $w_c$;\n- eje vertical: evitación intergrupal $w_o$.\n\nPara cada punto ejecutamos varias semillas y promediamos el tramo final. Esto reduce el riesgo de dibujar como “fase” un accidente de una sola inicialización.\n\n> **Costo computacional.** El barrido rápido usa pocos agentes y una grilla 7×7. Aumenta `repeats`, `steps` y la resolución solo después de verificar que la versión corta funciona."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "def phase_sweep(cohesion_values, avoidance_values, base=None,\n                steps=260, repeats=2, seed=1000):\n    base = base or replace(base_cfg, n_agents=54, alignment=.95, noise=.035)\n    rows = []\n    total = len(cohesion_values) * len(avoidance_values) * repeats\n    done = 0\n    start = time.time()\n    for avoid in avoidance_values:\n        for coh in cohesion_values:\n            for rep in range(repeats):\n                cfg = replace(base, cohesion=float(coh), outgroup_avoidance=float(avoid))\n                # La misma semilla por réplica se reutiliza en toda la grilla:\n                # comparación pareada que reduce variación ajena a los parámetros.\n                _, hist, _ = run_simulation(cfg, steps=steps, seed=seed+rep,\n                                            sample_every=10)\n                tail = hist.tail(max(5, len(hist)//4)).mean(numeric_only=True)\n                rows.append({\"cohesion\": coh, \"avoidance\": avoid, \"rep\": rep,\n                             \"P\": tail.polarization, \"S\": tail.segregation,\n                             \"B\": tail.boundary_exposure,\n                             \"neighbors\": tail.mean_neighbors})\n                done += 1\n    result = pd.DataFrame(rows)\n    print(f\"Barrido terminado: {total} simulaciones en {time.time()-start:.1f} s\")\n    return result\n\n\ncohesion_grid = np.round(np.linspace(0.00, 0.12, 7), 3)\navoidance_grid = np.round(np.linspace(0.00, 1.50, 7), 3)\nphase_raw = phase_sweep(cohesion_grid, avoidance_grid, steps=240, repeats=2)\nphase = phase_raw.groupby([\"avoidance\", \"cohesion\"], as_index=False).mean(numeric_only=True)\nphase.head()"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# @title Mapas cuantitativos del diagrama de fases\nfig, axes = plt.subplots(1, 3, figsize=(16, 4.8), constrained_layout=True)\nfor ax, col, title, cmap, bounds in [\n    (axes[0], \"P\", \"Orden direccional P\", \"Blues\", (0, 1)),\n    (axes[1], \"S\", \"Segregación S\", \"Oranges\", (-.1, 1)),\n    (axes[2], \"B\", \"Exposición a frontera B\", \"Greens\", (0, 1)),\n]:\n    table = phase.pivot(index=\"avoidance\", columns=\"cohesion\", values=col)\n    sns.heatmap(table, ax=ax, cmap=cmap, vmin=bounds[0], vmax=bounds[1],\n                annot=True, fmt=\".2f\", cbar_kws={\"shrink\": .75})\n    ax.invert_yaxis()\n    ax.set(title=title, xlabel=\"Cohesión intragrupal\", ylabel=\"Evitación intergrupal\")\nplt.show()"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# @title Clasificación pedagógica de regímenes\ndef classify_regime(row):\n    # Umbrales explícitos y editables: sirven para resumir, no para ocultar los datos.\n    if row.neighbors < 2.0:\n        return \"Fragmentado\"\n    if row.S >= .38 and row.P >= .45:\n        return \"Bandadas segregadas\"\n    if row.S >= .38:\n        return \"Segregado sin rumbo común\"\n    if row.P >= .55:\n        return \"Bandada mixta\"\n    return \"Mixto/desordenado\"\n\nphase[\"regime\"] = phase.apply(classify_regime, axis=1)\nregime_order = [\"Mixto/desordenado\", \"Bandada mixta\", \"Segregado sin rumbo común\",\n                \"Bandadas segregadas\", \"Fragmentado\"]\nphase[\"regime_code\"] = pd.Categorical(phase.regime, categories=regime_order).codes\nregime_table = phase.pivot(index=\"avoidance\", columns=\"cohesion\", values=\"regime_code\")\n\ncolors = [\"#B8B8B8\", \"#4C78A8\", \"#F2CF5B\", \"#F58518\", \"#8E5EA2\"]\nfig, ax = plt.subplots(figsize=(8.4, 6.2))\nsns.heatmap(regime_table, cmap=ListedColormap(colors), vmin=-.5, vmax=4.5,\n            linewidths=.6, linecolor=\"white\", cbar=False, ax=ax)\nax.invert_yaxis()\nax.set(title=\"Diagrama de regímenes (clasificación explícita)\",\n       xlabel=\"Cohesión intragrupal\", ylabel=\"Evitación intergrupal\")\nhandles = [plt.Line2D([0], [0], marker=\"s\", linestyle=\"\", markersize=11,\n                      markerfacecolor=c, markeredgecolor=\"none\", label=lab)\n           for c, lab in zip(colors, regime_order)]\nax.legend(handles=handles, bbox_to_anchor=(1.02, 1), loc=\"upper left\", frameon=False)\nplt.show()"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### Cómo interpretar el diagrama sin sobreafirmar\n\n1. Las fronteras de color son **zonas de transición estimadas**, no discontinuidades matemáticas demostradas.\n2. Los umbrales de clasificación son visibles en `classify_regime`; cambia los umbrales y comprueba robustez.\n3. Una fase exige estabilidad frente a tamaño poblacional, duración, semillas y resolución de la grilla.\n4. Si la desviación entre réplicas es grande, el dato correcto es “resultado incierto o multestable”, no una categoría forzada."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# @title Incertidumbre entre réplicas\nuncertainty = (phase_raw.groupby([\"avoidance\", \"cohesion\"])\n               .agg(S_mean=(\"S\", \"mean\"), S_sd=(\"S\", \"std\"),\n                    P_mean=(\"P\", \"mean\"), P_sd=(\"P\", \"std\"))\n               .reset_index())\ndisplay(uncertainty.sort_values(\"S_sd\", ascending=False).head(10).round(3))"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 8. Persistencia de fronteras: una intervención\n\n“Persistente” no significa eterna. Lo probaremos con un diseño en dos etapas:\n\n1. **Formación:** alta evitación intergrupal durante 350 pasos.\n2. **Intervención:** reducimos la evitación casi a cero sin reiniciar posiciones ni velocidades.\n\nSi $S$ cae instantáneamente, la frontera era solo una respuesta contemporánea. Si decae lentamente, el sistema exhibe **memoria estructural**: la configuración producida en el pasado condiciona el presente."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "def intervention_experiment(seed=7, pre_steps=350, post_steps=450,\n                            avoid_before=1.1, avoid_after=.03):\n    cfg_before = replace(base_cfg, cohesion=.075, alignment=1.0,\n                         outgroup_avoidance=avoid_before, noise=.025)\n    sim = MultiGroupBoids(cfg_before, seed=seed, init=\"mixed\")\n    rows = []\n    for _ in range(pre_steps):\n        if sim.t % 5 == 0:\n            rows.append({**metrics(sim), \"stage\": \"formación\"})\n        sim.step()\n\n    # Intervención: el estado se conserva; solo cambia la regla.\n    sim.cfg = replace(sim.cfg, outgroup_avoidance=avoid_after)\n    switch_t = sim.t\n    for _ in range(post_steps + 1):\n        if sim.t % 5 == 0:\n            rows.append({**metrics(sim), \"stage\": \"evitación reducida\"})\n        sim.step()\n    return sim, pd.DataFrame(rows), switch_t\n\n\nintervention_sim, intervention_hist, switch_t = intervention_experiment()\n\nfig, ax = plt.subplots(figsize=(10, 4.6))\nax.plot(intervention_hist.t, intervention_hist.segregation, lw=2.3,\n        color=\"#F58518\", label=\"Segregación S\")\nax.plot(intervention_hist.t, intervention_hist.boundary_exposure, lw=2.0,\n        color=\"#54A24B\", label=\"Exposición B\")\nax.axvline(switch_t, color=\"#333333\", ls=\"--\", lw=1.5,\n           label=\"Intervención: baja la evitación\")\nax.set(xlabel=\"Paso\", ylabel=\"Métrica\", ylim=(-.1, 1.05),\n       title=\"¿Sobrevive la frontera al cambio de regla?\")\nax.legend(ncols=3, loc=\"upper center\", bbox_to_anchor=(.5, 1.16))\nplt.show()"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 9. Sensibilidad y reproducibilidad\n\nLos sistemas no lineales pueden amplificar pequeñas diferencias. Por eso una semilla no es “ruido que hay que ocultar”: es una dimensión del experimento."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# @title Distribución de resultados sobre múltiples semillas\ndef seed_ensemble(config, seeds=range(12), steps=400):\n    rows = []\n    for seed in seeds:\n        _, hist, _ = run_simulation(config, steps=steps, seed=seed, sample_every=10)\n        tail = hist.tail(10).mean(numeric_only=True)\n        rows.append({\"seed\": seed, \"P\": tail.polarization, \"S\": tail.segregation,\n                     \"B\": tail.boundary_exposure, \"neighbors\": tail.mean_neighbors})\n    return pd.DataFrame(rows)\n\nensemble = seed_ensemble(base_cfg)\ndisplay(ensemble.describe().round(3))\n\nfig, axes = plt.subplots(1, 3, figsize=(13, 3.8), constrained_layout=True)\nfor ax, col, color in zip(axes, [\"P\", \"S\", \"B\"], PALETTE):\n    sns.stripplot(data=ensemble, y=col, ax=ax, color=color, size=7, jitter=.08)\n    ax.axhline(ensemble[col].mean(), color=\"black\", lw=1, ls=\"--\")\n    ax.set(title=f\"{col} entre semillas\", xlabel=\"\", ylabel=col, ylim=(-.05, 1.05))\nplt.show()"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 10. De aves a drones, redes y agentes de IA\n\n| Dominio | Agente | Vecindad | “Alineamiento” | Riesgo de extrapolación |\n|---|---|---|---|---|\n| Aves o peces | individuo | distancia/sensores | dirección y velocidad | omitir aerodinámica, depredación y jerarquías |\n| Drones | vehículo | radio, red o visión | rumbo/protocolo | ignorar latencia, obstáculos y seguridad |\n| Red social | cuenta/persona | enlaces o exposición | opinión/acción | confundir homofilia con influencia |\n| Naciones o ejércitos | organización | alianzas, geografía | postura estratégica | antropomorfizar y borrar instituciones |\n| Agentes de IA | proceso/modelo | canal de comunicación | política o representación | suponer autonomía donde hay diseño humano |\n\n### Principio metodológico\n\nLa transferencia válida no consiste en decir “las naciones son pájaros”, sino en preguntar si distintos sistemas comparten una **estructura de interacción local**, identificar qué variables corresponden y buscar datos que puedan refutar la analogía.\n\n### Cuatro límites importantes\n\n- El modelo asigna identidades fijas; en sistemas sociales reales las identidades pueden ser múltiples y cambiar.\n- La geometría física no equivale automáticamente a distancia cultural, política o informacional.\n- Los agentes humanos anticipan, interpretan reglas y modifican instituciones.\n- Los resultados pueden alimentar narrativas normativas; aquí son resultados descriptivos de reglas explícitas."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 11. Actividades propuestas\n\n### Nivel 1 — Comprensión\n\n1. Pon `outgroup_avoidance=0`. ¿Puede aparecer segregación solo por cohesión intragrupal?\n2. Pon `cohesion=0` y conserva alineamiento. ¿Se forman bandadas compactas o corrientes dispersas?\n3. Aumenta `noise` gradualmente. Estima el punto donde $P$ deja de ser estable.\n\n### Nivel 2 — Diseño experimental\n\n4. Repite el diagrama con 30, 60 y 120 agentes. ¿Las fronteras de fase cambian?\n5. Compara inicialización `mixed` y `segregated` con los mismos parámetros. Si el estado final depende del inicio, documenta multestabilidad o histéresis.\n6. Sustituye el radio métrico por los $k$ vecinos más próximos. ¿Qué propiedades dependen de densidad?\n\n### Nivel 3 — Extensión\n\n7. Añade obstáculos o recursos y mide si las fronteras coinciden con el ambiente.\n8. Permite alineamiento intergrupal positivo. ¿Cuándo surge coordinación global sin mezcla espacial?\n9. Haz que la identidad del grupo pueda cambiar según vecinos. ¿Aparecen consenso, ciclos o dominios móviles?\n10. Para drones, añade retardo de comunicación y perturbaciones; evalúa colisiones y robustez.\n\n### Entrega sugerida\n\nFormula una hipótesis, define variable independiente, métricas y controles; ejecuta al menos 10 semillas; informa promedio, dispersión y un caso atípico; concluye sin extrapolar más allá del modelo."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 12. Síntesis\n\n1. **Reglas simples no implican resultados simples.** Las interacciones locales se realimentan y crean patrones macroscópicos.\n2. **Orden no es segregación.** $P$, $S$ y $B$ responden preguntas diferentes.\n3. **Una imagen no es evidencia suficiente.** Se necesitan métricas, réplicas, controles y análisis de sensibilidad.\n4. **Las fronteras pueden tener memoria.** Un patrón espacial puede persistir aun después de cambiar la regla que lo formó.\n5. **Una analogía es una hipótesis, no una identidad.** El modelo puede inspirar preguntas sobre peces, drones, redes o IA, pero no reemplaza la teoría ni los datos de cada dominio.\n\n### Referencias conceptuales\n\n- Reynolds, C. W. (1987). *Flocks, Herds and Schools: A Distributed Behavioral Model*.\n- Vicsek, T. et al. (1995). *Novel Type of Phase Transition in a System of Self-Driven Particles*.\n- Schelling, T. C. (1971). *Dynamic Models of Segregation*.\n- Wolfram, C. *Phase diagram of boids: complex global behavior emerging from simple local rules*, Wolfram Community.\n\n> El modelo de este notebook es una implementación didáctica original en Python/NumPy inspirada en la familia BOIDS; no es una traducción línea por línea del notebook de Wolfram Language."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Apéndice A — Exportar resultados"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# @title Guardar tablas para análisis posterior\n# Descomenta si quieres descargar los resultados desde Colab.\n# phase_raw.to_csv(\"boids_phase_diagram_raw.csv\", index=False)\n# ensemble.to_csv(\"boids_seed_ensemble.csv\", index=False)\n\nprint(\"Objetos disponibles:\")\nprint(\"  base_hist            → trayectoria base\")\nprint(\"  scenario_df          → comparación de escenarios\")\nprint(\"  phase_raw / phase    → diagrama de fases\")\nprint(\"  intervention_hist    → persistencia de fronteras\")\nprint(\"  ensemble             → sensibilidad a semillas\")"
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": [],
+   "toc_visible": true
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.x"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Qué cambia

- Incorpora el notebook `boids-multigrupo-diagrama-fases.ipynb` al módulo de Grafos.
- Añade una tarjeta destacada y visualmente consistente en la portada del repositorio.
- Añade una introducción académica completa en `src/classroom/graphs/README.md`.
- Incluye un botón principal **Abrir laboratorio · Google Colab** que apunta directamente al Colab compartido.
- Incluye un botón secundario estable para consultar el notebook versionado en GitHub.

## Por qué

El laboratorio amplía la ruta docente de grafos, autómatas y sistemas complejos con una simulación basada en agentes. Permite estudiar cómo separación, alineamiento, cohesión y evitación intergrupal producen orden, segregación y fronteras emergentes.

## Impacto

La incorporación mejora la navegación y hace visible el nuevo recurso desde los dos puntos de entrada principales, sin alterar materiales existentes ni dependencias del repositorio.

## Verificaciones

- Notebook JSON válido: formato 4, 33 celdas y 15 celdas de código.
- Enlaces al Colab y al notebook comprobados en ambos README.
- Anclas de la tabla de contenidos incorporadas.
- Rama comparada con `main`: 3 archivos previstos, sin cambios ajenos.